### PR TITLE
Reset avatar error state to show profile images

### DIFF
--- a/src/components/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
 
@@ -25,6 +25,11 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
   className
 }) => {
   const [imageError, setImageError] = useState(false);
+
+  // Reset error state when the image URL changes
+  useEffect(() => {
+    setImageError(false);
+  }, [profileImageUrl]);
 
   return (
     <Avatar className={cn(sizeClasses[size], className)}>

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -48,7 +48,7 @@ const useGameStore = create<GameState>()((set, get) => ({
         id: p.id,
         name: p.name,
         emoji: p.emoji,
-        profileImageUrl: p.profile_image_url,
+        profileImageUrl: p.profile_image_url || undefined,
         rating: p.rating,
         exposureCount: p.exposure_count,
         winCount: p.win_count,


### PR DESCRIPTION
## Summary
- reset avatar image error state when profile URL changes to allow valid profile pictures to render
- treat empty profile image URLs as undefined when loading players

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, require() style import is forbidden)*
- `npx eslint src/components/PlayerAvatar.tsx src/stores/gameStore.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c821cff4cc832194b5c0a4a8a54ddf