### PR TITLE
Reset avatar error state to show profile images

### DIFF
--- a/src/components/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
 
@@ -26,12 +26,19 @@ export const PlayerAvatar: React.FC<PlayerAvatarProps> = ({
 }) => {
   const [imageError, setImageError] = useState(false);
 
+  // Reset error state when the image URL changes
+  useEffect(() => {
+    setImageError(false);
+  }, [profileImageUrl]);
+
   return (
     <Avatar className={cn(sizeClasses[size], className)}>
       {profileImageUrl && !imageError && (
         <AvatarImage
+          key={profileImageUrl}
           src={profileImageUrl}
           alt={`${name} profile picture`}
+          crossOrigin="anonymous"
           onError={() => setImageError(true)}
         />
       )}

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -44,16 +44,29 @@ const useGameStore = create<GameState>()((set, get) => ({
       
       if (error) throw error;
       
-      const formattedPlayers: Player[] = players?.map(p => ({
-        id: p.id,
-        name: p.name,
-        emoji: p.emoji,
-        profileImageUrl: p.profile_image_url,
-        rating: p.rating,
-        exposureCount: p.exposure_count,
-        winCount: p.win_count,
-        lossCount: p.loss_count,
-      })) || [];
+      const formattedPlayers: Player[] =
+        players?.map((p) => {
+          const rawUrl = p.profile_image_url?.trim();
+          let profileUrl: string | undefined;
+
+          if (rawUrl) {
+            profileUrl = rawUrl.startsWith('http')
+              ? rawUrl
+              : supabase.storage.from('players').getPublicUrl(rawUrl).data
+                  .publicUrl;
+          }
+
+          return {
+            id: p.id,
+            name: p.name,
+            emoji: p.emoji,
+            profileImageUrl: profileUrl,
+            rating: p.rating,
+            exposureCount: p.exposure_count,
+            winCount: p.win_count,
+            lossCount: p.loss_count,
+          };
+        }) || [];
       
       set({ players: formattedPlayers });
     } catch (error) {


### PR DESCRIPTION
## Summary
- reset avatar image error state when profile URL changes to allow valid profile pictures to render
- treat empty profile image URLs as undefined when loading players
- build public storage URLs for player profile images and remount avatar images for new URLs

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A require() style import is forbidden)*
- `npx eslint src/components/PlayerAvatar.tsx src/stores/gameStore.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c821cff4cc832194b5c0a4a8a54ddf