### PR TITLE
Support local profile image assets

### DIFF
--- a/public/Assets/README.md
+++ b/public/Assets/README.md
@@ -1,0 +1,3 @@
+# Assets Folder
+
+Place player profile images in this directory. Files stored here can be referenced from the database using paths like `/Assets/your-image.png`.

--- a/src/pages/DebugImages.tsx
+++ b/src/pages/DebugImages.tsx
@@ -27,6 +27,10 @@ const DebugImages = () => {
         if (rawUrl) {
           if (rawUrl.startsWith('http')) {
             publicUrl = rawUrl;
+          } else if (rawUrl.startsWith('/')) {
+            publicUrl = rawUrl;
+          } else if (rawUrl.toLowerCase().startsWith('assets/')) {
+            publicUrl = `/${rawUrl}`;
           } else {
             const path = rawUrl.replace(/^players\//, '');
             publicUrl = supabase.storage

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -52,6 +52,10 @@ const useGameStore = create<GameState>()((set, get) => ({
           if (rawUrl) {
             if (rawUrl.startsWith('http')) {
               profileUrl = rawUrl;
+            } else if (rawUrl.startsWith('/')) {
+              profileUrl = rawUrl;
+            } else if (rawUrl.toLowerCase().startsWith('assets/')) {
+              profileUrl = `/${rawUrl}`;
             } else {
               const path = rawUrl.replace(/^players\//, '');
               profileUrl = supabase.storage


### PR DESCRIPTION
## Summary
- add a public/Assets directory and document how to reference bundled profile images
- allow profile image URLs in Supabase data to point at local `/Assets/...` paths
- update the debug page to resolve local asset paths the same way

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83e7a0690832198b91903c77569f5