### PR TITLE
Normalize local profile image paths

### DIFF
--- a/public/Assets/README.md
+++ b/public/Assets/README.md
@@ -1,0 +1,3 @@
+# Assets Folder
+
+Place player profile images in this directory. Files stored here can be referenced from the database using paths like `/Assets/your-image.png`.

--- a/src/pages/DebugImages.tsx
+++ b/src/pages/DebugImages.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { resolveProfileImageUrl } from '@/utils/profileImage';
 
 interface DebugPlayer {
   id: string;
@@ -23,17 +24,7 @@ const DebugImages = () => {
       }
       const mapped = (data || []).map((p) => {
         const rawUrl = p.profile_image_url?.trim() || null;
-        let publicUrl: string | undefined;
-        if (rawUrl) {
-          if (rawUrl.startsWith('http')) {
-            publicUrl = rawUrl;
-          } else {
-            const path = rawUrl.replace(/^players\//, '');
-            publicUrl = supabase.storage
-              .from('players')
-              .getPublicUrl(path).data.publicUrl;
-          }
-        }
+        const publicUrl = resolveProfileImageUrl(rawUrl);
         if (publicUrl) {
           fetch(publicUrl)
             .then((res) => {

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { Player, Vote, VotePair, EloUpdate } from '@/types/goat';
 import { calculateElo } from '@/utils/elo';
 import { supabase } from '@/integrations/supabase/client';
+import { resolveProfileImageUrl } from '@/utils/profileImage';
 
 interface GameState {
   players: Player[];
@@ -46,19 +47,7 @@ const useGameStore = create<GameState>()((set, get) => ({
       
       const formattedPlayers: Player[] =
         players?.map((p) => {
-          const rawUrl = p.profile_image_url?.trim();
-          let profileUrl: string | undefined;
-
-          if (rawUrl) {
-            if (rawUrl.startsWith('http')) {
-              profileUrl = rawUrl;
-            } else {
-              const path = rawUrl.replace(/^players\//, '');
-              profileUrl = supabase.storage
-                .from('players')
-                .getPublicUrl(path).data.publicUrl;
-            }
-          }
+          const profileUrl = resolveProfileImageUrl(p.profile_image_url);
 
           return {
             id: p.id,

--- a/src/utils/profileImage.ts
+++ b/src/utils/profileImage.ts
@@ -1,0 +1,38 @@
+import { supabase } from '@/integrations/supabase/client';
+
+const ASSET_PREFIX_REGEX = /^\.?\/?(?:public\/)?assets\//i;
+
+const normalizeLocalAssetPath = (value: string): string | undefined => {
+  if (!ASSET_PREFIX_REGEX.test(value)) {
+    return undefined;
+  }
+
+  const remainder = value.replace(ASSET_PREFIX_REGEX, '').replace(/^\/+/, '');
+  return remainder ? `/Assets/${remainder}` : '/Assets';
+};
+
+export const resolveProfileImageUrl = (
+  rawUrl: string | null | undefined,
+): string | undefined => {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const assetPath = normalizeLocalAssetPath(trimmed);
+  if (assetPath) {
+    return assetPath;
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  const storagePath = trimmed.replace(/^players\//i, '');
+  const { data } = supabase.storage.from('players').getPublicUrl(storagePath);
+  return data?.publicUrl || undefined;
+};


### PR DESCRIPTION
## Summary
- add a shared helper to resolve profile image URLs, including local `Assets/...` paths
- update the player loader and debug page to use the shared resolver so local assets map to `/Assets/...`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83e7a0690832198b91903c77569f5