### PR TITLE
Fix asset URL normalization for player profile images

### DIFF
--- a/src/utils/profileImage.ts
+++ b/src/utils/profileImage.ts
@@ -1,14 +1,24 @@
 import { supabase } from '@/integrations/supabase/client';
 
-const ASSET_PREFIX_REGEX = /^\.?\/?(?:public\/)?assets\//i;
+const ASSET_PREFIX_REGEX = /^\.?\/?((?:public\/)?assets\/)/i;
 
 const normalizeLocalAssetPath = (value: string): string | undefined => {
-  if (!ASSET_PREFIX_REGEX.test(value)) {
+  const match = value.match(ASSET_PREFIX_REGEX);
+  if (!match) {
     return undefined;
   }
 
-  const remainder = value.replace(ASSET_PREFIX_REGEX, '').replace(/^\/+/, '');
-  return remainder ? `/Assets/${remainder}` : '/Assets';
+  const remainder = value.slice(match[0].length).replace(/^\/+/, '');
+
+  let assetPrefix = match[1];
+  if (/^public\//i.test(assetPrefix)) {
+    assetPrefix = assetPrefix.slice(assetPrefix.indexOf('/') + 1);
+  }
+
+  assetPrefix = assetPrefix.replace(/\/+$/, '');
+
+  const normalizedPath = remainder ? `${assetPrefix}/${remainder}` : assetPrefix;
+  return `/${normalizedPath}`.replace(/\/+/g, '/');
 };
 
 export const resolveProfileImageUrl = (


### PR DESCRIPTION
## Summary
- preserve the original casing of local asset prefixes when resolving profile image URLs
- strip optional public/ prefix, trim duplicate slashes, and normalize the generated path

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84871ae9c8321a4e00c13340a387b